### PR TITLE
Update mongodb to avoid bson warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "mongotiles is a tilelive backend plug-in for MongoDB GridFS",
   "main": "lib/index.js",
   "dependencies": {
-    "mongodb": "~1.4.4",
+    "mongodb": "~2.1.18",
     "gridfs-locks": ">=1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I found that many dependencies were outdated. So I tried to upgrade them, resulted in test failure. Actually, the original test is already broken.
However, upgrading mongodb will be safe
